### PR TITLE
Fix type of reference code

### DIFF
--- a/src/API/ReviewInvite.php
+++ b/src/API/ReviewInvite.php
@@ -30,10 +30,10 @@ class ReviewInvite
      * @param  string $firstName
      * @param  string $lastName
      * @param  int    $delay
-     * @param  int    $refCode
+     * @param  string $refCode
      * @return bool
      */
-    public function sendInvite(string $email, string $firstName, string $lastName, int $delay = 0, int $refCode = 0): bool
+    public function sendInvite(string $email, string $firstName, string $lastName, int $delay = 0, string $refCode = null): bool
     {
         $curl = curl_init(ReviewInvite::$url);
 

--- a/src/Models/Reviews/ReviewContentModel.php
+++ b/src/Models/Reviews/ReviewContentModel.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace KingsCode\KlantenVertellen\Models\Reviews;
@@ -9,11 +8,20 @@ use KingsCode\KlantenVertellen\Models\Model;
 class ReviewContentModel extends Model
 {
     /**
+     * @deprecated
      * @return string
      */
     public function getAnswerToQuestion(): string
     {
         return $this->answerToQuestion;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRating(): string
+    {
+        return $this->rating;
     }
 
     /**
@@ -35,7 +43,7 @@ class ReviewContentModel extends Model
     /**
      * @return string
      */
-    public function getOrder(): string
+    public function getOrder(): int
     {
         return $this->order;
     }


### PR DESCRIPTION
This PR changes the type of `$refCode` from integer to string. For explanation, see: https://github.com/kingscode/php-klanten-vertellen-api/pull/5#issuecomment-905694479.